### PR TITLE
ch1285/custom-requirements-must-have-unique-ids

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -122,3 +122,6 @@
 
 0.6.28 /2017-09-19
     * Schema fix so that ports[].public_port and ports[].private_port can be ints or strings, instead of only strings
+
+0.6.29 /2017-09-19
+    * Check that custom_requirements have unique ids

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "replicated-lint",
     "author": "Replicated, Inc.",
-    "version": "0.6.28",
+    "version": "0.6.29",
     "engines": {
         "node": ">=4.3.2"
     },

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -8,6 +8,7 @@ import {
   ConfigOptionIsCircular,
   ContainerNamesNotUnique,
   ContainerVolumesFromMissing,
+  CustomRequirementsNotUnique,
   Dot,
   Eq,
   EventSubscriptionContainerMissing,
@@ -84,6 +85,7 @@ const defaultPredicates: PredicateRegistry = {
   InvalidURL,
   ContainerVolumesFromMissing,
   ContainerNamesNotUnique,
+  CustomRequirementsNotUnique,
 };
 
 export class MutableRegistry implements Registry {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -136,6 +136,7 @@ export interface Test {
   ContainerVolumesFromMissing?: {};
   EventSubscriptionContainerMissing?: {};
   WhenExpressionConfigInvalid?: {};
+  CustomRequirementsNotUnique?: {};
 
   MoreThan?: {
     limit: number;

--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -998,3 +998,37 @@ export class IsNotUint implements Predicate<any> {
     };
   }
 }
+
+export class CustomRequirementsNotUnique implements Predicate<any> {
+  public static fromJson(): CustomRequirementsNotUnique {
+    return new CustomRequirementsNotUnique();
+  }
+
+  public test(root: any): RuleMatchedAt {
+    if (_.isEmpty(root.custom_requirements)) {
+      return { matched: false };
+    }
+
+    const seenNames = {} as any;
+    const matches = _.flatMap(root.custom_requirements, (requirement: any, requirementIndex) => {
+      if (_.isUndefined(requirement.id)) {
+        return [{ matched: false }];
+      }
+
+      if (_.isUndefined(seenNames[requirement.id])) {
+        seenNames[requirement.id] = `requirements.${requirementIndex}.id`;
+        return { matched: false };
+      }
+
+      return {
+        matched: true,
+        paths: [
+          `requirements.${requirementIndex}.id`,
+          seenNames[requirement.id],
+        ],
+      };
+    });
+
+    return collapseMatches(matches);
+  }
+}

--- a/src/rules/configoption.ts
+++ b/src/rules/configoption.ts
@@ -397,10 +397,59 @@ config:
   },
 };
 
+export const customRequirementIdsUnique: YAMLRule = {
+  name: "prop-component-container-names-unique",
+  type: "error",
+  message: "Custom requirements must have unique ids",
+  test: {   CustomRequirementsNotUnique : {}},
+  examples: {
+    wrong: [
+      {
+        description: "duplicated ids",
+        yaml: `
+---
+custom_requirements:
+- id: alpha
+  message: beta
+- id: alpha
+  message: delta
+    `,
+      },
+      {
+        description: "seperated duplicated ids",
+        yaml: `
+---
+custom_requirements:
+- id: alpha
+  message: beta
+- id: gamma
+  message: delta
+- id: alpha
+  message: zeta
+    `,
+      },
+    ],
+    right: [
+      {
+        description: "no duplicated ids",
+        yaml: `
+---
+custom_requirements:
+- id: alpha
+  message: beta
+- id: gamma
+  message: delta
+    `,
+      },
+    ],
+  },
+};
+
 export const all: YAMLRule[] = [
   configOptionExists,
   configOptionPasswordType,
   configOptionNotCircular,
   configOptionTypeValid,
   configOptionWhenValid,
+  customRequirementIdsUnique,
 ];


### PR DESCRIPTION
verifies custom_requirements ids are unique
add new predicate: CustomRequirementsNotUnique, called from root. Very similar to ContainerNamesNotUnique
update changelog, update version# in package.json