### PR TITLE
Ch1284/container using volumes from subscription fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -142,3 +142,6 @@
 0.6.34 /2017-09-25
     * Added value checking to `components.*.containers.*.volumes.*.is_ephemeral` and `.is_excluded_from_backup`
     * Now can only be booleans literals, boolean strings, or templates
+
+0.6.35 /2017-09-29
+    * Fix `volumes_from` subscription validation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "replicated-lint",
     "author": "Replicated, Inc.",
-    "version": "0.6.34",
+    "version": "0.6.35",
     "engines": {
         "node": ">=4.3.2"
     },

--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -1098,10 +1098,12 @@ export class ContainerVolumesFromSubscription implements Predicate<any> {
 
           // find what component has a container of this name
           let subscribedComponentName: string = "";
+          let subscribedContainerImageName: string = "";
           for (const otherComponent of root.components) {
             for (const otherContainer of otherComponent.containers) {
-              if (otherContainer.image_name === subscribedName) {
+              if (otherContainer.name === subscribedName) {
                 subscribedComponentName = otherComponent.name;
+                subscribedContainerImageName = otherContainer.image_name;
               }
             }
           }
@@ -1117,7 +1119,7 @@ export class ContainerVolumesFromSubscription implements Predicate<any> {
           // get subscription map
           const subscriptionMap: { [s: string]: string; } = buildSubscriptionMap(root);
 
-          const found: boolean = dependsOn(subscriptionMap, component.name + ":" + container.image_name, subscribedComponentName + ":" + subscribedName);
+          const found: boolean = dependsOn(subscriptionMap, component.name + ":" + container.image_name, subscribedComponentName + ":" + subscribedContainerImageName);
 
           if (!found) {
             return {

--- a/src/rules/containers.ts
+++ b/src/rules/containers.ts
@@ -803,7 +803,8 @@ export const containerVolumesSubscriptionExists: YAMLRule = {
 components:
 - name: DB
   containers:
-  - image_name: notalpha
+  - name: notalpha
+    image_name: irrelevant
     publish_events:
     - subscriptions:
       - component: DB
@@ -820,7 +821,8 @@ components:
 components:
 - name: DB
   containers:
-  - image_name: alpha
+  - name: alpha
+    image_name: irrelevant
     publish_events:
     - subscriptions:
       - component: DB
@@ -837,7 +839,8 @@ components:
 components:
 - name: DB
   containers:
-  - image_name: alpha
+  - name: alpha
+    image_name: irrelevant
     publish_events:
     - subscriptions:
       - component: DB
@@ -862,7 +865,7 @@ components:
     publish_events:
     - subscriptions:
       - component: DB
-        container: alpha
+        container: alphaname
     `,
       },
     ],
@@ -874,7 +877,8 @@ components:
 components:
 - name: DB
   containers:
-  - image_name: alpha
+  - name: alpha
+    image_name: irrelevant
     publish_events:
     - subscriptions:
       - component: DB
@@ -891,7 +895,8 @@ components:
 components:
 - name: DB
   containers:
-  - image_name: alpha
+  - name: alpha
+    image_name: irrelevant
     publish_events:
     - subscriptions:
       - component: DB
@@ -913,7 +918,8 @@ components:
 components:
 - name: DB
   containers:
-  - image_name: alpha
+  - name: alpha
+    image_name: irrelevant
     publish_events:
     - subscriptions:
       - component: DB2


### PR DESCRIPTION
Changed to use `name` to find root container, and then use `image_name` to traverse that container as before