### PR TITLE
Support for custom restore script in snapshots.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -332,3 +332,6 @@
 
 0.12.11 2018-07-18
     * Core: Add `source` and `image_name` as required fields for `components.*.containers`
+
+0.12.12 2018-07-25
+    * Core: Add `restore_script` property to backup and backup strategies

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -198,6 +198,9 @@ export const schema: JSONSchema4 = {
         "script": {
           "type": "string",
         },
+        "restore_script": {
+          "type": "string",
+        },
         "swarm": {
           "type": "object",
           "properties": {
@@ -242,6 +245,9 @@ export const schema: JSONSchema4 = {
                 "type": ["string", "boolean"],
               },
               "script": {
+                "type": "string",
+              },
+              "restore_script": {
                 "type": "string",
               },
               "kubernetes": {


### PR DESCRIPTION
This can be used as the reverse of the custom back up script.

- [ ] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated.
- [ ] If any changes need to be deployed, the version has been bumped in `package.json`.
- [ ] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
