### PR TITLE
Fix for failed deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             exit 1
           fi
       - checkout
-      - run: npm install publish@^0.6.0
+      - run: $(npm -g bin)/yarn
       - deploy:
           name: publish
           command: |


### PR DESCRIPTION
- [-] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated.
- [-] If any changes need to be deployed, the version has been bumped in `package.json`.
- [-] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
