### PR TITLE
add ability to pass project in CLI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -402,3 +402,6 @@
 
 0.13.19 2018-10-24
     * Add `kustomizeIntro` property to `replicated-ship`
+
+0.13.20 2018-10-24
+    * Add `--project` flag to `replicated-lint validate` command to pull schema+rules from another project

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "engines": {
     "node": ">=4.3.2"
   },


### PR DESCRIPTION
What I Did
------------

Add `--project` flag for setting a project to validate against.

How I Did it
------------

update `validate.ts` to check for project and override rules/schema. If `--schema` is specified, it overrides the project schema. If `--extraRules` is specified, they are appended to the project's rules.

How to verify it
------------

    npx replicated-lint --project replicatedShip -f path/to/ship.yaml