### PR TITLE
add config item write_once property

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -408,3 +408,6 @@
 
 0.13.21 2018-10-25
     * Add support for test procedure custom commands
+
+0.13.22 2018-10-26
+    * Add write_once property to config item

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -906,6 +906,9 @@ export const schema: JSONSchema4 = {
                 "readonly": {
                   "type": "boolean",
                 },
+                "write_once": {
+                  "type": "boolean",
+                },
                 "recommended": {
                   "type": "boolean",
                 },


### PR DESCRIPTION
- [ ] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated.
- [x] If any changes need to be deployed, the version has been bumped in `package.json`.
- [x] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
