### PR TITLE
Add when property to test_proc and container volumes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -432,3 +432,7 @@
 
 0.14.6 2018-11-20
     * Add proxy key to ship github assets to replace source key
+
+0.14.7 2018-12-5
+    * Add `when` property to `test_proc` config items
+    * Add `when` property to container volumes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -712,6 +712,9 @@ export const schema: JSONSchema4 = {
                       "permission": {
                         "type": "string",
                       },
+                      "when": {
+                        "type": ["string", "boolean"],
+                      },
                     },
                   },
                 },
@@ -997,6 +1000,9 @@ export const schema: JSONSchema4 = {
                     },
                     "timeout": {
                       "type": "integer",
+                    },
+                    "when": {
+                      "type": ["string", "boolean"],
                     },
                   },
                 },


### PR DESCRIPTION
- [x] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated (`make project-import PROJECT=<project-name>`).
- [x] If any changes need to be deployed, the version has been bumped in `package.json`.
- [x] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
