### PR TITLE
Group test proc missing when

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -446,3 +446,6 @@
 0.14.10 2019-01-10
     * Add `when` property to `terraform` lifecycle steps
 
+0.14.11 2019-01-11
+    * Config group `test_proc` missing `when` property
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -1118,6 +1118,9 @@ export const schema: JSONSchema4 = {
               "timeout": {
                 "type": "integer",
               },
+              "when": {
+                "type": ["string", "boolean"],
+              },
             },
           },
           "title": {

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -1,5 +1,7 @@
 import { JSONSchema4 } from "json-schema";
 
+// NOTE: THIS FILE IS *NOT* GENERATED
+
 export const schema: JSONSchema4 = {
   "$schema": "http://json-schema.org/schema#",
   "type": "object",


### PR DESCRIPTION
- [x] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated (`make project-import PROJECT=<project-name>`).
- [x] If any changes need to be deployed, the version has been bumped in `package.json`.
- [x] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
