### PR TITLE
`identity.enabled` can be a bool or a string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -460,3 +460,6 @@
 
 0.14.15 2019-02-01
     * Linter now allows templates in the `components.containers.cluster_instance_count` sub-keys
+
+0.14.16 2019-02-01
+    * Allow `enabled` flags under `identity` be boolean

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.14.15",
+  "version": "0.14.16",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -1321,7 +1321,7 @@ export const schema: JSONSchema4 = {
       "type": "object",
       "properties": {
         "enabled": {
-          "type": "string",
+          "type": ["string", "boolean"],
         },
         "provisioner": {
           "type": "string",
@@ -1332,7 +1332,7 @@ export const schema: JSONSchema4 = {
             "type": "object",
             "properties": {
               "enabled": {
-                "type": "string",
+                "type": ["string", "boolean"],
               },
               "filter": {
                 "type": "string",


### PR DESCRIPTION
- [x] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated (`make project-import PROJECT=<project-name>`).
- [x] If any changes need to be deployed, the version has been bumped in `package.json`.
- [x] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
