### PR TITLE
Fix --excludeDefaults stdout assertion

### DIFF
--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -92,11 +92,9 @@ describe("replicated-lint", () => {
           input: "]]]:",
         });
         expect(status).to.equal(1);
-        expect(stripAnsi(stdout.toString())).to.contain(`{ type: 'error',
-  rule: 'mesg-yaml-valid',
-  message:
-   'end of the stream or a document separator is expected at line 1, column 1:\\n    ]]]:\\n    ^',
-  positions: [] }`);
+        expect(stripAnsi(stdout.toString())).to.contain("type: 'error'")
+        expect(stripAnsi(stdout.toString())).to.contain("rule: 'mesg-yaml-valid'")
+        expect(stripAnsi(stdout.toString())).to.contain("'end of the stream or a document separator is expected at line 1, column 1:\\n    ]]]:\\n    ^'");
       });
     });
     describe("--multidocIndex", () => {

--- a/src/test/cli.ts
+++ b/src/test/cli.ts
@@ -92,8 +92,8 @@ describe("replicated-lint", () => {
           input: "]]]:",
         });
         expect(status).to.equal(1);
-        expect(stripAnsi(stdout.toString())).to.contain("type: 'error'")
-        expect(stripAnsi(stdout.toString())).to.contain("rule: 'mesg-yaml-valid'")
+        expect(stripAnsi(stdout.toString())).to.contain("type: 'error'");
+        expect(stripAnsi(stdout.toString())).to.contain("rule: 'mesg-yaml-valid'");
         expect(stripAnsi(stdout.toString())).to.contain("'end of the stream or a document separator is expected at line 1, column 1:\\n    ]]]:\\n    ^'");
       });
     });


### PR DESCRIPTION
The output sometimes includes a newline after "message:" but before the
message string literal. This accepts either way.

- [ ] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated (`make project-import PROJECT=<project-name>`).
- [ ] If any changes need to be deployed, the version has been bumped in `package.json`.
- [ ] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
