### PR TITLE
add kubernetes.shared_fs.mount_paths

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -492,3 +492,6 @@
 
 0.17.0 2019-07-09
     * Support bundle `lifecycle` now includes v1 prefix
+
+0.18.0 2019-09-05
+    * Add kubernetes shared filesystem mount paths

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -1405,6 +1405,12 @@ export const schema: JSONSchema4 = {
             "enabled": {
               "type": ["string", "boolean"],
             },
+            "mount_paths": {
+              "type": "array",
+              "items": {
+                "type": "string",
+              },
+            },
           },
         },
         "requirements": {


### PR DESCRIPTION
- [ ] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated (`make project-import PROJECT=<project-name>`).
- [x] If any changes need to be deployed, the version has been bumped in `package.json`.
- [x] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
