### PR TITLE
feat: user and readonly_rootfs container properties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -534,3 +534,7 @@
 
 0.19.1 2022-06-06
     * Upgraded junit-report-builder to 3.0.0.
+
+0.19.2 2023-03-13
+    * Added `container.user` a string
+    * Added `container.readonly_rootfs` a boolean or string

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/projects/replicated-entitlements/docs-generated.md
+++ b/projects/replicated-entitlements/docs-generated.md
@@ -44,5 +44,53 @@ Entitlement Spec keys must be unique
 
 
 
-*Generated at Mon Mar 09 2020 12:54:29 GMT-0700 (Pacific Daylight Time)*
+*Generated at Mon Mar 13 2023 23:21:27 GMT+0000 (Coordinated Universal Time)*
+
+
+## `spec-prop-unique-keys`
+
+Entitlement Spec keys must be unique
+
+
+
+
+
+#### Examples:
+
+*Incorrect*: spec has duplicated key `my_field`
+
+```yaml---
+- name: My Field
+  type: string
+  description: My cool field
+  key: my_field
+- name: My Other Field
+  type: number
+  description: some other field
+  key: my_field
+
+```
+
+
+
+*Correct*: Spec keys have unique names
+
+```yaml---
+- name: My Field
+  key: my_field
+  description: My cool field
+  type: string
+- name: My Other Field
+  key: my_other_field
+  description: some other field
+  type: number
+
+```
+
+
+    
+
+
+
+*Generated at Mon Mar 13 2023 23:21:27 GMT+0000 (Coordinated Universal Time)*
 

--- a/src/replicated.ts
+++ b/src/replicated.ts
@@ -616,6 +616,8 @@ type Container struct {
 	Links                  []string                   `yaml:"links,omitempty" json:"links,omitempty" validate:"omitempty"`
 	IPv4Address            string                     `yaml:"ipv4_address,omitempty" json:"ipv4_address,omitempty" validate:"omitempty"`
 	IPv6Address            string                     `yaml:"ipv6_address,omitempty" json:"ipv6_address,omitempty" validate:"omitempty"`
+	User                   string                     `yaml:"user,omitempty" json:"user,omitempty" validate:"omitempty"`
+	ReadonlyRootfs         BoolString                 `yaml:"readonly_rootfs,omitempty" json:"readonly_rootfs,omitempty" validate:"omitempty,bool"`
 }
 type ContainerRestartPolicy struct {
 	Policy string `yaml:"policy" json:"policy"`
@@ -873,6 +875,16 @@ export interface Container {
    *
    */
   ipv6_address?: string;
+
+  /**
+   *
+   */
+  user?: string;
+
+  /**
+   *
+   */
+  readonly_rootfs?: BoolString;
 }
 
 export interface ContainerRestartPolicy {

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -703,6 +703,12 @@ export const schema: JSONSchema4 = {
                 "ipv6_address": {
                   "type": "string",
                 },
+                "user": {
+                  "type": "string",
+                },
+                "readonly_rootfs": {
+                  "type": ["string", "boolean"],
+                },
                 "support_commands": {
                   "type": "array",
                   "items": {


### PR DESCRIPTION
- [x] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated (`make project-import PROJECT=<project-name>`).
- [x] If any changes need to be deployed, the version has been bumped in `package.json`.
- [x] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
