### PR TITLE
feat: allow raw container cmds to run with readonly_rootfs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -538,3 +538,7 @@
 0.19.2 2023-03-13
     * Added `container.user` a string
     * Added `container.readonly_rootfs` a boolean or string
+
+0.19.3 2023-03-23
+    * Added `cmds.readonly_rootfs` a boolean
+    * Added `state.ready.readonly_rootfs` a boolean or string

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replicated-lint",
   "author": "Replicated, Inc.",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "engines": {
     "node": ">=4.3.2"
   },

--- a/src/schemas/parsed.ts
+++ b/src/schemas/parsed.ts
@@ -319,6 +319,9 @@ export const schema: JSONSchema4 = {
           "name": {
             "type": "string",
           },
+          "readonly_rootfs": {
+            "type": "boolean",
+          },
         },
       },
     },
@@ -1663,6 +1666,9 @@ export const schema: JSONSchema4 = {
             },
             "timeout": {
               "type": "integer",
+            },
+            "readonly_rootfs": {
+              "type": ["string", "boolean"],
             },
           },
         },


### PR DESCRIPTION
- [x] If any changes have been made to `/project` files, the corresponding `/src` files have been regenerated (`make project-import PROJECT=<project-name>`).
- [x] If any changes need to be deployed, the version has been bumped in `package.json`.
- [x] If any changes impact the replicated-lint package, they have been added to `CHANGELOG`.
